### PR TITLE
fix: typo OSSへの後見

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -242,7 +242,7 @@ AI ヘッドハンティングサービス LAPRAS SCOUT の開発に従事。
   </tbody>
 </table>
 
-#### その他 OSS への後見
+#### その他 OSS への貢献
 - **type-challenges のメンバー（日本語ローカライズを担当）**
     - [type-challenges](https://github.com/type-challenges/type-challenges)
 - Raycast 拡張機能の開発


### PR DESCRIPTION
`貢献`が`後見`になっていたので修正しました。